### PR TITLE
fix: file too large with minio ui uploads

### DIFF
--- a/conf/minio.conf.tpl
+++ b/conf/minio.conf.tpl
@@ -28,7 +28,7 @@ server {
     location / {
         # Reverse proxy settings
         include /gateway/conf/proxy.conf;
-        include /gateway/conf/proxy_extra.conf;
+        include /gateway/conf/proxy_timeouts.conf;
         proxy_connect_timeout 300;
         # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
         proxy_set_header Connection "";
@@ -44,7 +44,7 @@ server {
     location /minio/ui/ {
         # General reverse proxy settings
         include /gateway/conf/proxy.conf;
-        include /gateway/conf/proxy_extra.conf;
+        include /gateway/conf/proxy_timeouts.conf;
 
         # This is necessary to pass the correct IP to be hashed
         proxy_set_header X-NginX-Proxy true;

--- a/conf/proxy_extra.conf
+++ b/conf/proxy_extra.conf
@@ -2,5 +2,3 @@ client_body_timeout     660s;
 proxy_read_timeout      660s;
 proxy_send_timeout      660s;
 send_timeout            660s;
-
-client_max_body_size    200m;

--- a/conf/proxy_extra.conf
+++ b/conf/proxy_extra.conf
@@ -1,4 +1,8 @@
-client_body_timeout     660s;
-proxy_read_timeout      660s;
-proxy_send_timeout      660s;
-send_timeout            660s;
+# NOTICE:
+# This file is referenced by mounted configurations for Bento services.
+# See Katsu example: 
+# https://github.com/bento-platform/bento/blob/main/lib/gateway/public_services/katsu.conf.tpl
+
+include /gateway/conf/proxy_timeouts.conf;
+
+client_max_body_size    200m;

--- a/conf/proxy_timeouts.conf
+++ b/conf/proxy_timeouts.conf
@@ -1,0 +1,4 @@
+client_body_timeout     660s;
+proxy_read_timeout      660s;
+proxy_send_timeout      660s;
+send_timeout            660s;


### PR DESCRIPTION
Minio includes a config in the UI path that limits the max body size, preventing large file uploads from the UI.
Changes:
- NEW `proxy_timeouts.conf`
   - Timeouts defs from old `proxy_extra.conf`
- EDIT `proxy_extra.conf`
   -  Replace timeouts with include
   - `include proxy_timeouts.conf`
- EDIT `minio.conf.tpl` 
   - Keep timeouts, leave out max body size
   - ~`include proxy_extra.conf`~
   - `include proxy_timeouts.conf`