### PR TITLE
chore: investigate garage reverse proxy s3 signature errors

### DIFF
--- a/conf/garage.conf.tpl
+++ b/conf/garage.conf.tpl
@@ -28,11 +28,10 @@ server {
         proxy_connect_timeout 300;
         #proxy_set_header Connection "";
         chunked_transfer_encoding off;
-
+        
+        proxy_set_header Host $http_host;
         proxy_pass http://${BENTO_GARAGE_CONTAINER_NAME}:${BENTO_GARAGE_S3_API_PORT};
-
-        proxy_set_header Host $host;
-
+        proxy_max_temp_file_size 0;
         error_log /var/log/bentov2_garage_errors.log;
     }
 }
@@ -68,10 +67,9 @@ server {
         #proxy_set_header Connection "";
         chunked_transfer_encoding off;
 
+        proxy_set_header Host $http_host;
         proxy_pass http://${BENTO_GARAGE_CONTAINER_NAME}:${BENTO_GARAGE_ADMIN_PORT};
-
-        proxy_set_header Host $host;
-
+        proxy_max_temp_file_size 0;
         error_log /var/log/bentov2_garage_errors.log;
     }
 }

--- a/conf/garage.conf.tpl
+++ b/conf/garage.conf.tpl
@@ -26,7 +26,7 @@ server {
         include /gateway/conf/proxy_timeouts.conf;
 
         proxy_connect_timeout 300;
-        proxy_set_header Connection "";
+        #proxy_set_header Connection "";
         chunked_transfer_encoding off;
 
         proxy_pass http://${BENTO_GARAGE_CONTAINER_NAME}:${BENTO_GARAGE_S3_API_PORT};
@@ -65,7 +65,7 @@ server {
         include /gateway/conf/proxy_timeouts.conf;
 
         proxy_connect_timeout 300;
-        proxy_set_header Connection "";
+        #proxy_set_header Connection "";
         chunked_transfer_encoding off;
 
         proxy_pass http://${BENTO_GARAGE_CONTAINER_NAME}:${BENTO_GARAGE_ADMIN_PORT};


### PR DESCRIPTION
This PR is mostly intended to build images to troubleshoot live Garage deployments behind a reverse-proxy.

We are not able to expose Garage v2.3.0 with the current proxy configs.